### PR TITLE
Dockerfile to build for centos 6

### DIFF
--- a/builder-support/dockerfiles/Dockerfile.target.centos-6
+++ b/builder-support/dockerfiles/Dockerfile.target.centos-6
@@ -1,0 +1,3 @@
+FROM centos:6
+
+RUN yum -y update && yum -y install autoconf automake libtool gcc libpng-devel libudev-devel pango-devel libdrm-devel


### PR DESCRIPTION
Basic docker image with the required packages to build for Centos 6.x